### PR TITLE
Input System Cleanup

### DIFF
--- a/Assets/Scripts/Radar.cs
+++ b/Assets/Scripts/Radar.cs
@@ -169,36 +169,35 @@ public class Radar : MonoBehaviour
 
         // scroll radar w/ mouse wheel
         radarCamera.transform.position += new Vector3(0, Input.mouseScrollDelta.y *10, 0);
- 
-        if (Input.GetKey(KeyCode.Alpha1))
-        {
-            if (radarZoomLevel != 1)
-            {
-                radarCamera.transform.position = new Vector3(radarCamera.transform.position.x, zoom1_y, radarCamera.transform.position.z);
-                radarZoomLevel = 1;
-                changeRadarIconScale(zoom1_scale);
-            }
-        }
+        
+        //Zoom code for levels changed to OnChangeZoom function
 
-        if (Input.GetKey(KeyCode.Alpha2))
-        {
-            if (radarZoomLevel != 2)
-            {
-                radarCamera.transform.position = new Vector3(radarCamera.transform.position.x, zoom2_y, radarCamera.transform.position.z);
-                radarZoomLevel = 2;
-                changeRadarIconScale(zoom2_scale);
-            }
-        }
+    }
 
-        if (Input.GetKey(KeyCode.Alpha3))
-        {
-            if (radarZoomLevel != 3)
-            {
-                radarCamera.transform.position = new Vector3(radarCamera.transform.position.x, zoom3_y, radarCamera.transform.position.z); ;
-                radarZoomLevel = 3;
-                changeRadarIconScale(zoom3_scale);
-            }
+    public void OnChangeZoom()
+    {
+        radarZoomLevel++;
+        if (radarZoomLevel > 3) //I dislike this magic number. It would be nicer to have a list of zooms instead
+            radarZoomLevel = 1; //Roll the value back to zero
+        float zoom_scale = 0;
+        float zoom_y = 0;
+        switch (radarZoomLevel)
+        { //Ew, assigning the scale like this feels dirty, but oh well
+            case 1:
+                zoom_scale = zoom1_scale;
+                zoom_y = zoom1_y;
+                break;
+            case 2:
+                zoom_scale = zoom2_scale;
+                zoom_y = zoom2_y;
+                break;
+            case 3:
+                zoom_scale = zoom3_scale;
+                zoom_y = zoom3_y;
+                break;
         }
+        radarCamera.transform.position = new Vector3(radarCamera.transform.position.x, zoom_y, radarCamera.transform.position.z);
+        changeRadarIconScale(zoom_scale);
     }
 
     private void changeRadarIconScale(float newScale)

--- a/Assets/tankControls.inputactions
+++ b/Assets/tankControls.inputactions
@@ -13,6 +13,33 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "CameraToggle",
+                    "type": "Button",
+                    "id": "ed761698-7eb7-4674-94b6-0f00a1a32b0c",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ChangeZoom",
+                    "type": "Button",
+                    "id": "6c293c1d-8518-4d25-8263-d519162794ab",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleRadarMinimap",
+                    "type": "Button",
+                    "id": "d9899221-44da-4345-bb33-53f491edf2eb",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -70,6 +97,39 @@
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "21eb2d26-8abc-444c-94d8-77c36e4da9a5",
+                    "path": "<Keyboard>/c",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CameraToggle",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "939af15e-bf70-402f-9e9d-5a5a12cbcddd",
+                    "path": "<Keyboard>/z",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ChangeZoom",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "85fefd8d-b2ca-4571-b0b9-2e03e04381e7",
+                    "path": "<Keyboard>/r",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ToggleRadarMinimap",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         }

--- a/Assets/tankSteer.cs
+++ b/Assets/tankSteer.cs
@@ -96,37 +96,35 @@ public class tankSteer : MonoBehaviour
 
     }
 
-    private void Update()
+    public void OnMove(InputValue value)
     {
-        if (Input.GetKeyDown(KeyCode.C))
-        {
-            if (firstPersonCam.enabled)
-            {
-                firstPersonCam.enabled = false;
-                overHeadCam.enabled = true;
-            } else
-            {
-                firstPersonCam.enabled = true;
-                overHeadCam.enabled = false;
-            }
-        }
+        driverInput = value.Get<Vector2>();
+    }
 
-        if (Input.GetKeyDown(KeyCode.R))
+    public void OnCameraToggle()
+    {
+        if (firstPersonCam.enabled)
         {
-            if (radarCanvas.enabled)
-            {
-                radarCanvas.enabled = false;
-            }
-            else
-            {
-                radarCanvas.enabled = true;
-            }
+            firstPersonCam.enabled = false;
+            overHeadCam.enabled = true;
+        }
+        else
+        {
+            firstPersonCam.enabled = true;
+            overHeadCam.enabled = false;
         }
     }
 
-    private void OnMove(InputValue value)
+    public void OnToggleRadarMinimap()
     {
-        driverInput = value.Get<Vector2>();
+        if (radarCanvas.enabled)
+        {
+            radarCanvas.enabled = false;
+        }
+        else
+        {
+            radarCanvas.enabled = true;
+        }
     }
 
 }


### PR DESCRIPTION
I removed most of the hardcoded keypresses from the tankSteer and Radar scripts, replacing them with keybindings in the Input Action Asset. The most notable change is the zoom no long being keys 1-3 and instead being a single keybind of z. Pressing z cycles between the different levels, and the tankSteer had the hide radar button replaced as well.
This pull request also changes the PlayerInput on the tank to use BroadcastMessages rather than SendMessages as the radar is a child of the tank and wouldn't have gotten the input messages otherwise.
Everything is tested and working, though I did leave in the hardcoded scroll wheel adjusting the radar's zoom level for now. I figured it would be useful in debug situations.